### PR TITLE
merge v1.1.1 changes into master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y \
     socat \
     --no-install-recommends && \
     rm -rf /var/lib/apt/lists/*
-RUN pip install pyserial
+RUN pip install pyserial==2.7
 RUN pip install flask
 RUN pip install requests
 RUN pip install uwsgi

--- a/opendcre_southbound/__init__.py
+++ b/opendcre_southbound/__init__.py
@@ -303,13 +303,6 @@ def opendcre_scan(packet, bus, retry_count=0):
                 })
             logger.debug(" * FLASK (scan) <<: " + str([hex(x) for x in response_packet.serialize()]))
 
-    # if we get here, the scan was successful, so we can save the scan state.
-    # we don't expect a response for a save command, so after writing to the
-    # bus, we can return the aggregated scan results.
-    board_id = SCAN_ALL_BOARD_ID | SAVE_BOARD_ID
-    save_packet = devicebus.DumpCommand(board_id=board_id, sequence=next(_count))
-    bus.write(save_packet.serialize())
-
     return response_dict
 
 

--- a/opendcre_southbound/version.py
+++ b/opendcre_southbound/version.py
@@ -28,6 +28,6 @@
 """
 __version_major__ = "1"
 __version_minor__ = "1"
-__version_micro__ = "0"
+__version_micro__ = "1"
 __api_version__ = __version_major__+"."+__version_minor__
 __version__ = __api_version__+"."+__version_micro__


### PR DESCRIPTION
Pyserial is broken upstream (v3.0), so we will use v2.7 until pyserial is stable - this should allow downstream container-builders to be able to rebuild OpenDCRE using the older pyserial version.

The changes for vestigial code in scan are also included, to remove erroneous retry logic that is not yet implemented in OpenDCRE hardware.  More robust logic will be included in v1.2.0 of OpenDCRE.