### PR TITLE
minor fixes in v1.2.0 docs

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -10,24 +10,20 @@ Scan
 Description
 -----------
 
-- The ``scan`` command polls boards and devices attached to the board.  The ``scan`` command takes a ``board_id`` as its argument, and returns an array of board and device descriptors. If no ``board_id`` is provided, the ``scan`` command scans all boards on the device bus.
+The ``scan`` command polls boards and devices attached to the board.  The ``scan`` command takes a ``board_id`` as its argument, and returns an array of board and device descriptors. If no ``board_id`` is provided, the ``scan`` command scans all boards on the device bus.
 
-Notes
------
-
-- It is likely a good idea for applications to scan for all boards on startup, to ensure a proper map of boards and devices is available to the application.  Mismatches of board and device types and identifiers will result in 500 errors being returned for various commands that rely on these values mapping to actual hardware.
+.. note::
+    It is likely a good idea for applications to scan for all boards on startup, to ensure a proper map of boards and devices is available to the application.  Mismatches of board and device types and identifiers will result in 500 errors being returned for various commands that rely on these values mapping to actual hardware.
 
 Request Format
 --------------
 
-- Scan devices on a specific ``board_id``:
-
+Scan devices on a specific ``board_id``:
 ::
 
     http://<ipaddress>:<port>/opendcre/<version>/scan/<board_id>
 
-- Scan all boards on the device bus:
-
+Scan all boards on the device bus:
 ::
 
     http://<ipaddress>:<port>/opendcre/<version>/scan
@@ -35,7 +31,7 @@ Request Format
 Parameters
 ----------
 
-- ``board_id`` (optional) : Hexadecimal string representation of 4-byte integer value - range 00000000..FFFFFFFF.  Upper byte of ``board_id`` reserved for future use in OpenDCRE.  IPMI Bridge boards have a special ``board_id`` of 40NNNNNN (where NNNNNN is the hex string id of each configured BMC).
+:board_id: (optional) Hexadecimal string representation of 4-byte integer value - range 00000000..FFFFFFFF.  Upper byte of ``board_id`` reserved for future use in OpenDCRE.  IPMI Bridge boards have a special ``board_id`` of 40NNNNNN (where NNNNNN is the hex string id of each configured BMC).
 
 Request Example
 ---------------
@@ -131,7 +127,7 @@ Example Response
 Errors
 ------
 
-- Returns error (500) if scan command fails, or if ``board_id`` corresponds to an invalid ``board_id``.
+Returns error (500) if scan command fails, or if ``board_id`` corresponds to an invalid ``board_id``.
 
 Version
 =======
@@ -202,7 +198,7 @@ Read Device
 Description
 -----------
 
-- Read a value from the given ``board_id`` and ``device_id`` for a specific ``device_type``.  The specified ``device_type`` must match the actual physical device type (as reported by the ``scan`` command), and is used to return a translated raw reading value (e.g. temperature in C for a thermistor) based on the existing algorithm for a given sensor type.  The raw value is also returned.
+Read a value from the given ``board_id`` and ``device_id`` for a specific ``device_type``.  The specified ``device_type`` must match the actual physical device type (as reported by the ``scan`` command), and is used to return a translated raw reading value (e.g. temperature in C for a thermistor) based on the existing algorithm for a given sensor type.  The raw value is also returned.
 
 Request Format
 --------------
@@ -213,17 +209,15 @@ Request Format
 Parameters
 ----------
 
-- ``device_type`` :  String value (lower-case) indicating what type of device to read
+:device_type:  String value (lower-case) indicating what type of device to read
     - ``thermistor``
     - ``temperature``
     - ``humidity``
     - ``led``
     - ``fan_speed``
     - ``pressure`` (not implemented yet)
-
-- ``board_id`` : Hexadecimal string representation of 4-byte integer value - range 00000000..FFFFFFFF.  Upper byte of ``board_id`` reserved for future use in OpenDCRE.  IPMI Bridge board has a special ``board_id`` of 40NNNNNN (where NNNNNN is the hex string id of each individual BMC configured with the IPMI Bridge).
-
-- ``device_id`` : The device to read on the specified board.  Hexadecimal string representation of a 2-byte integer value - range 0000..FFFF.  Must be a valid, existing device, where the ``device_type`` known to  OpenDCRE matches the ``device_type`` specified in the command for the given device - else, a 500 error is returned.
+:board_id: Hexadecimal string representation of 4-byte integer value - range 00000000..FFFFFFFF.  Upper byte of ``board_id`` reserved for future use in OpenDCRE.  IPMI Bridge board has a special ``board_id`` of 40NNNNNN (where NNNNNN is the hex string id of each individual BMC configured with the IPMI Bridge).
+:device_id: The device to read on the specified board.  Hexadecimal string representation of a 2-byte integer value - range 0000..FFFF.  Must be a valid, existing device, where the ``device_type`` known to  OpenDCRE matches the ``device_type`` specified in the command for the given device - else, a 500 error is returned.
 
 Request Example
 ---------------
@@ -259,7 +253,7 @@ Example Response
 Errors
 ------
 
-- If a device is not readable or does not exist, an error (500) is returned.
+If a device is not readable or does not exist, an error (500) is returned.
 
 Get Asset Information
 =====================
@@ -267,7 +261,7 @@ Get Asset Information
 Description
 -----------
 
-- Get asset information from the given ``board_id`` and ``device_id``.  The device's ``device_type`` must be of type ``system`` (as reported by the ``scan`` command), and is used to return asset information for a given device.
+Get asset information from the given ``board_id`` and ``device_id``.  The device's ``device_type`` must be of type ``system`` (as reported by the ``scan`` command), and is used to return asset information for a given device.
 
 Request Format
 --------------
@@ -278,9 +272,8 @@ Request Format
 Parameters
 ----------
 
-- ``board_id`` : Hexadecimal string representation of 4-byte integer value - range 00000000..FFFFFFFF.  Upper byte of ``board_id`` reserved for future use in OpenDCRE.  IPMI Bridge board has a special ``board_id`` of 40NNNNNN, where NNNNNN corresponds to the hex string id of each configured BMC.
-
-- ``device_id`` : The device to read asset information for on the specified board.  Hexadecimal string representation of a 2-byte integer value - range 0000..FFFF.  Must be a valid, existing device, where the ``device_type`` known to OpenDCRE is of type ``system`` - else, a 500 error is returned.
+:board_id: Hexadecimal string representation of 4-byte integer value - range 00000000..FFFFFFFF.  Upper byte of ``board_id`` reserved for future use in OpenDCRE.  IPMI Bridge board has a special ``board_id`` of 40NNNNNN, where NNNNNN corresponds to the hex string id of each configured BMC.
+:device_id: The device to read asset information for on the specified board.  Hexadecimal string representation of a 2-byte integer value - range 0000..FFFF.  Must be a valid, existing device, where the ``device_type`` known to OpenDCRE is of type ``system`` - else, a 500 error is returned.
 
 Request Example
 ---------------
@@ -389,7 +382,7 @@ Example Response
 Errors
 ------
 
-- If asset info is unavailable or does not exist, an error (500) is returned.
+If asset info is unavailable or does not exist, an error (500) is returned.
 
 Power
 =====
@@ -397,7 +390,7 @@ Power
 Description
 -----------
 
-- Control device power, and/or retrieve its power supply status.
+Control device power, and/or retrieve its power supply status.
 
 Request Format
 --------------
@@ -408,11 +401,9 @@ Request Format
 Parameters
 ----------
 
-- ``board_id`` : Hexadecimal string representation of 4-byte integer value - range 00000000..FFFFFFFF.  Upper byte of ``board_id`` reserved for future use in OpenDCRE.  IPMI Bridge board has a special ``board_id`` of 40NNNNNN, where NNNNNN corresponds to the hex string id of each configured BMC.
-
-- ``device_id`` : The device to issue power command to on the specified board.  Hexadecimal string representation of 2-byte integer value - range 0000..FFFF.  Must be a valid, existing device, where the ``device_type`` known to OpenDCRE is ``power`` - else, a 500 error is returned.
-
-- ``command`` (optional) :
+:board_id: Hexadecimal string representation of 4-byte integer value - range 00000000..FFFFFFFF.  Upper byte of ``board_id`` reserved for future use in OpenDCRE.  IPMI Bridge board has a special ``board_id`` of 40NNNNNN, where NNNNNN corresponds to the hex string id of each configured BMC.
+:device_id: The device to issue power command to on the specified board.  Hexadecimal string representation of 2-byte integer value - range 0000..FFFF.  Must be a valid, existing device, where the ``device_type`` known to OpenDCRE is ``power`` - else, a 500 error is returned.
+:command: (optional)
     - ``on`` : Turn power on to specified device.
     - ``off`` : Turn power off to specified device.
     - ``cycle`` : Power-cycle the specified device.
@@ -482,7 +473,7 @@ Example Response
 Errors
 ------
 
-- If a power action fails, or an invalid board/device combination are specified, an error (500) is returned.
+If a power action fails, or an invalid board/device combination are specified, an error (500) is returned.
 
 Boot Target
 ===========
@@ -490,7 +481,7 @@ Boot Target
 Description
 -----------
 
-- The boot target command may be used to get or set the boot target for a given device (whose device_type must be ``system``).  The boot_target command takes two required parameters - ``board_id`` and ``device_id``, to identify the device to direct the boot_target command to.  Additionally, a third, optional parameter, ``target`` may be used to set the boot target.
+The boot target command may be used to get or set the boot target for a given device (whose device_type must be ``system``).  The boot_target command takes two required parameters - ``board_id`` and ``device_id``, to identify the device to direct the boot_target command to.  Additionally, a third, optional parameter, ``target`` may be used to set the boot target.
 
 Request Format
 --------------
@@ -501,11 +492,9 @@ Request Format
 Parameters
 ----------
 
-- ``board_id`` : Hexadecimal string representation of 4-byte integer value - range 00000000..FFFFFFFF.  Upper byte of ``board_id`` reserved for future use in OpenDCRE.  IPMI Bridge board has a special ``board_id`` of 40NNNNNN, where NNNNNN corresponds to the hex string id of each configured BMC.
-
-- ``device_id`` : The device to issue boot target command to on the specified board.  Hexadecimal string representation of 2-byte integer value - range 0000..FFFF.  Must be a valid, existing device, where the ``device_type`` known to OpenDCRE is ``system`` - else, a 500 error is returned.
-
-- ``target`` (optional) :
+:board_id: Hexadecimal string representation of 4-byte integer value - range 00000000..FFFFFFFF.  Upper byte of ``board_id`` reserved for future use in OpenDCRE.  IPMI Bridge board has a special ``board_id`` of 40NNNNNN, where NNNNNN corresponds to the hex string id of each configured BMC.
+:device_id: The device to issue boot target command to on the specified board.  Hexadecimal string representation of 2-byte integer value - range 0000..FFFF.  Must be a valid, existing device, where the ``device_type`` known to OpenDCRE is ``system`` - else, a 500 error is returned.
+:target: (optional)
     - ``hdd`` : boot to hard disk
     - ``pxe`` : boot to network
     - ``no_override`` : use the system default boot target
@@ -547,7 +536,7 @@ Example Response
 Errors
 ------
 
-- If a boot target action fails, or an invalid board/device combination are specified, an error (500) is returned.
+If a boot target action fails, or an invalid board/device combination are specified, an error (500) is returned.
 
 Location
 ========
@@ -555,7 +544,7 @@ Location
 Description
 -----------
 
-- The location command returns the physical location of a given board in the rack, if known, and may also include a given device's position within a chassis (when ``device_id`` is specified).  IPMI boards return ``unknown`` for all fields of ``physical_location`` as location information is not provided by IPMI.
+The location command returns the physical location of a given board in the rack, if known, and may also include a given device's position within a chassis (when ``device_id`` is specified).  IPMI boards return ``unknown`` for all fields of ``physical_location`` as location information is not provided by IPMI.
 
 Request Format
 --------------
@@ -566,100 +555,98 @@ Request Format
 Parameters
 ----------
 
-- ``board_id`` : Hexadecimal string representation of 4-byte integer value - range 00000000..FFFFFFFF.  Upper byte of ``board_id`` reserved for future use in OpenDCRE.  IPMI Bridge board has a special ``board_id`` of 40NNNNNN, where NNNNNN corresponds to the hex string id of each configured BMC.
-
-- ``device_id`` (optional) : The device to get location for on the specified board.  Hexadecimal string representation of 2-byte integer value - range 0000..FFFF.  Must be a valid, existing device known to OpenDCRE - else, a 500 error is returned.
+:board_id: Hexadecimal string representation of 4-byte integer value - range 00000000..FFFFFFFF.  Upper byte of ``board_id`` reserved for future use in OpenDCRE.  IPMI Bridge board has a special ``board_id`` of 40NNNNNN, where NNNNNN corresponds to the hex string id of each configured BMC.
+:device_id: (optional) The device to get location for on the specified board.  Hexadecimal string representation of 2-byte integer value - range 0000..FFFF.  Must be a valid, existing device known to OpenDCRE - else, a 500 error is returned.
 
 Response Schema
 ---------------
--Device Location:
 
-.. code-block:: json
+Device Location
+    .. code-block:: json
 
-    {
-      "$schema": "http://schemas.vapor.io/opendcre/v1.2/opendcre-1.2-device-location",
-      "title": "OpenDCRE Device Location",
-      "type": "object",
-      "properties": {
-        "chassis_location": {
+        {
+          "$schema": "http://schemas.vapor.io/opendcre/v1.2/opendcre-1.2-device-location",
+          "title": "OpenDCRE Device Location",
           "type": "object",
           "properties": {
-            "depth": {
-              "type": "string"
+            "chassis_location": {
+              "type": "object",
+              "properties": {
+                "depth": {
+                  "type": "string"
+                },
+                "horiz_pos": {
+                  "type": "string"
+                },
+                "vert_pos": {
+                  "type": "string"
+                },
+                "server_node": {
+                  "type": "string"
+                }
+              }
             },
-            "horiz_pos": {
-              "type": "string"
-            },
-            "vert_pos": {
-              "type": "string"
-            },
-            "server_node": {
-              "type": "string"
-            }
-          }
-        },
-        "physical_location": {
-          "type": "object",
-          "properties": {
-            "depth": {
-              "type": "string"
-            },
-            "horizontal": {
-              "type": "string"
-            },
-            "vertical": {
-              "type": "string"
-            }
-          }
-        }
-      }
-    }
-
-- Board Location:
-
-.. code-block:: json
-
-    {
-      "$schema": "http://schemas.vapor.io/opendcre/v1.2/opendcre-1.2-board-location",
-      "title": "OpenDCRE BoardLocation",
-      "type": "object",
-      "properties": {
-        "physical_location": {
-          "type": "object",
-          "properties": {
-            "depth": {
-              "type": "string"
-            },
-            "horizontal": {
-              "type": "string"
-            },
-            "vertical": {
-              "type": "string"
+            "physical_location": {
+              "type": "object",
+              "properties": {
+                "depth": {
+                  "type": "string"
+                },
+                "horizontal": {
+                  "type": "string"
+                },
+                "vertical": {
+                  "type": "string"
+                }
+              }
             }
           }
         }
-      }
-    }
+
+Board Location
+    .. code-block:: json
+
+        {
+          "$schema": "http://schemas.vapor.io/opendcre/v1.2/opendcre-1.2-board-location",
+          "title": "OpenDCRE BoardLocation",
+          "type": "object",
+          "properties": {
+            "physical_location": {
+              "type": "object",
+              "properties": {
+                "depth": {
+                  "type": "string"
+                },
+                "horizontal": {
+                  "type": "string"
+                },
+                "vertical": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
 
 Example Responses
 -----------------
-- Device Location:
 
-.. code-block:: json
+Device Location
+    .. code-block:: json
 
-    {
-      "chassis_location": {
-        "depth": "unknown",
-        "horiz_pos": "unknown",
-        "server_node": "unknown",
-        "vert_pos": "unknown"
-      },
-      "physical_location": {
-        "depth": "unknown",
-        "horizontal": "unknown",
-        "vertical": "unknown"
-      }
-    }
+        {
+          "chassis_location": {
+            "depth": "unknown",
+            "horiz_pos": "unknown",
+            "server_node": "unknown",
+            "vert_pos": "unknown"
+          },
+          "physical_location": {
+            "depth": "unknown",
+            "horizontal": "unknown",
+            "vertical": "unknown"
+          }
+        }
 
 - Valid values for ``chassis_location`` ``depth`` fields are ``front``, ``middle`` and ``rear``.
 
@@ -669,17 +656,16 @@ Example Responses
 
 - ``unknown`` is a valid value for any location field.
 
-- Board Location:
+Board Location
+    .. code-block:: json
 
-.. code-block:: json
-
-    {
-      "physical_location": {
-        "depth": "unknown",
-        "horizontal": "unknown",
-        "vertical": "unknown"
-      }
-    }
+        {
+          "physical_location": {
+            "depth": "unknown",
+            "horizontal": "unknown",
+            "vertical": "unknown"
+          }
+        }
 
 - Valid values for ``physical_location`` ``depth`` fields are: ``front``, ``middle``, and ``rear``.
 
@@ -692,7 +678,7 @@ Example Responses
 Errors
 ------
 
-- If a location command fails, or an invalid board/device combination are specified, an error (500) is returned.
+If a location command fails, or an invalid board/device combination are specified, an error (500) is returned.
 
 LED Control
 ===========
@@ -700,7 +686,7 @@ LED Control
 Description
 -----------
 
-- The LED control command is used to get and set the chassis "identify" LED state.  ``led`` devices known to OpenDCRE allow LED state to be set and retrieved.
+The LED control command is used to get and set the chassis "identify" LED state.  ``led`` devices known to OpenDCRE allow LED state to be set and retrieved.
 
 Request Format
 --------------
@@ -711,11 +697,9 @@ Request Format
 Parameters
 ----------
 
-- ``board_id`` : Hexadecimal string representation of 4-byte integer value - range 00000000..FFFFFFFF.  Upper byte of ``board_id`` reserved for future use in OpenDCRE.  IPMI Bridge board has a special ``board_id`` of 40NNNNNN, where NNNNNN corresponds to the hex string id of each configured BMC.
-
-- ``device_id`` : The device to issue LED control command to on the specified board.  Hexadecimal string representation of 2-byte integer value - range 0000..FFFF.  Must be a valid, existing device, where the ``device_type`` known to OpenDCRE is ``led`` - else, a 500 error is returned.
-
-- ``led_state`` (optional) :
+:board_id: Hexadecimal string representation of 4-byte integer value - range 00000000..FFFFFFFF.  Upper byte of ``board_id`` reserved for future use in OpenDCRE.  IPMI Bridge board has a special ``board_id`` of 40NNNNNN, where NNNNNN corresponds to the hex string id of each configured BMC.
+:device_id: The device to issue LED control command to on the specified board.  Hexadecimal string representation of 2-byte integer value - range 0000..FFFF.  Must be a valid, existing device, where the ``device_type`` known to OpenDCRE is ``led`` - else, a 500 error is returned.
+:led_state: (optional)
     - ``on`` : Turn on the chassis identify LED.
     - ``off`` : Turn off the chassis identify LED.
 
@@ -753,7 +737,7 @@ Example Response
 Errors
 ------
 
-- If a LED control action fails, or an invalid board/device combination are specified, an error (500) is returned.
+If a LED control action fails, or an invalid board/device combination are specified, an error (500) is returned.
 
 
 Fan Speed
@@ -762,7 +746,7 @@ Fan Speed
 Description
 -----------
 
-- The fan control command is used to get and set the fan speed in RPM for a given fan.  ``fan_speed`` devices known to OpenDCRE that are not IPMI devices allow fan speed to be set and retrieved, while IPMI ``fan_speed`` devices are read-only.
+The fan control command is used to get and set the fan speed in RPM for a given fan.  ``fan_speed`` devices known to OpenDCRE that are not IPMI devices allow fan speed to be set and retrieved, while IPMI ``fan_speed`` devices are read-only.
 
 Request Format
 --------------
@@ -773,13 +757,11 @@ Request Format
 Parameters
 ----------
 
-- ``board_id`` : Hexadecimal string representation of 4-byte integer value - range 00000000..FFFFFFFF.  Upper byte of ``board_id`` reserved for future use in OpenDCRE.  IPMI Bridge board has a special ``board_id`` of 40NNNNNN, where NNNNNN corresponds to the hex string id of each configured BMC.
+:board_id: Hexadecimal string representation of 4-byte integer value - range 00000000..FFFFFFFF.  Upper byte of ``board_id`` reserved for future use in OpenDCRE.  IPMI Bridge board has a special ``board_id`` of 40NNNNNN, where NNNNNN corresponds to the hex string id of each configured BMC.
+:device_id: The device to issue fan control command to on the specified board.  Hexadecimal string representation of 2-byte integer value - range 0000..FFFF.  Must be a valid, existing device, where the ``device_type`` known to OpenDCRE is ``fan_speed`` - else, a 500 error is returned.
+:speed_rpm: (optional) Numeric decimal value to set fan speed to, in range of 0-10000.
 
-- ``device_id`` : The device to issue fan control command to on the specified board.  Hexadecimal string representation of 2-byte integer value - range 0000..FFFF.  Must be a valid, existing device, where the ``device_type`` known to OpenDCRE is ``fan_speed`` - else, a 500 error is returned.
-
-- ``speed_rpm`` (optional) : Numeric decimal value to set fan speed to, in range of 0-10000.
-
-    - If ``speed_rpm`` is not specified, the ``fan`` command makes no changes, and simply retrieves and returns the fan speed in RPM.  If ``speed_rpm`` is specified and valid, the ``fan`` command will return the updated fan speed value, as provided by the remote device.
+- If ``speed_rpm`` is not specified, the ``fan`` command makes no changes, and simply retrieves and returns the fan speed in RPM.  If ``speed_rpm`` is specified and valid, the ``fan`` command will return the updated fan speed value, as provided by the remote device.
 
 Request Example
 ---------------
@@ -815,7 +797,7 @@ Example Response
 Errors
 ------
 
-- If a fan speed action fails, or an invalid board/device combination are specified, an error (500) is returned.
+If a fan speed action fails, or an invalid board/device combination are specified, an error (500) is returned.
 
 Test
 ====
@@ -823,7 +805,7 @@ Test
 Description
 -----------
 
-- The test command may be used to verify that the OpenDCRE endpoint is up and running, but without attempting to address the device bus.  The command takes no arguments, and if successful, returns a simple status message of "ok".
+The test command may be used to verify that the OpenDCRE endpoint is up and running, but without attempting to address the device bus.  The command takes no arguments, and if successful, returns a simple status message of "ok".
 
 Request Format
 --------------
@@ -859,4 +841,4 @@ Example Response
 Errors
 ------
 
-- If the endpoint is not running no response will be returned, as the command will always return the response above while the endpoint is functional.
+If the endpoint is not running no response will be returned, as the command will always return the response above while the endpoint is functional.

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -146,7 +146,7 @@ Request Format
 Parameters
 ----------
 
-``board_id`` : Hexadecimal string representation of 4-byte integer value - range 00000000..FFFFFFFF.  Upper byte of ``board_id`` reserved for future use in OpenDCRE.  IPMI Bridge board has a special ``board_id`` of 40000000.
+:board_id: Hexadecimal string representation of 4-byte integer value - range 00000000..FFFFFFFF.  Upper byte of ``board_id`` reserved for future use in OpenDCRE.  IPMI Bridge board has a special ``board_id`` of 40000000.
 
 Request Example
 ---------------
@@ -209,13 +209,8 @@ Request Format
 Parameters
 ----------
 
-:device_type:  String value (lower-case) indicating what type of device to read
-    - ``thermistor``
-    - ``temperature``
-    - ``humidity``
-    - ``led``
-    - ``fan_speed``
-    - ``pressure`` (not implemented yet)
+:device_type:  String value (lower-case) indicating what type of device to read: ``thermistor``, ``temperature``,
+    ``humidity``, ``led``, ``fan_speed``, ``pressure`` (not implemented yet)
 :board_id: Hexadecimal string representation of 4-byte integer value - range 00000000..FFFFFFFF.  Upper byte of ``board_id`` reserved for future use in OpenDCRE.  IPMI Bridge board has a special ``board_id`` of 40NNNNNN (where NNNNNN is the hex string id of each individual BMC configured with the IPMI Bridge).
 :device_id: The device to read on the specified board.  Hexadecimal string representation of a 2-byte integer value - range 0000..FFFF.  Must be a valid, existing device, where the ``device_type`` known to  OpenDCRE matches the ``device_type`` specified in the command for the given device - else, a 500 error is returned.
 
@@ -403,11 +398,10 @@ Parameters
 
 :board_id: Hexadecimal string representation of 4-byte integer value - range 00000000..FFFFFFFF.  Upper byte of ``board_id`` reserved for future use in OpenDCRE.  IPMI Bridge board has a special ``board_id`` of 40NNNNNN, where NNNNNN corresponds to the hex string id of each configured BMC.
 :device_id: The device to issue power command to on the specified board.  Hexadecimal string representation of 2-byte integer value - range 0000..FFFF.  Must be a valid, existing device, where the ``device_type`` known to OpenDCRE is ``power`` - else, a 500 error is returned.
-:command: (optional)
-    - ``on`` : Turn power on to specified device.
-    - ``off`` : Turn power off to specified device.
-    - ``cycle`` : Power-cycle the specified device.
-    - ``status`` : Get power status for the specified device.
+:command: (optional) ``on`` : Turn power on to specified device.
+    ``off`` : Turn power off to specified device.
+    ``cycle`` : Power-cycle the specified device.
+    ``status`` : Get power status for the specified device.
 
 For all commands, power status is returned as the command's response.
 
@@ -495,9 +489,9 @@ Parameters
 :board_id: Hexadecimal string representation of 4-byte integer value - range 00000000..FFFFFFFF.  Upper byte of ``board_id`` reserved for future use in OpenDCRE.  IPMI Bridge board has a special ``board_id`` of 40NNNNNN, where NNNNNN corresponds to the hex string id of each configured BMC.
 :device_id: The device to issue boot target command to on the specified board.  Hexadecimal string representation of 2-byte integer value - range 0000..FFFF.  Must be a valid, existing device, where the ``device_type`` known to OpenDCRE is ``system`` - else, a 500 error is returned.
 :target: (optional)
-    - ``hdd`` : boot to hard disk
-    - ``pxe`` : boot to network
-    - ``no_override`` : use the system default boot target
+    ``hdd`` : boot to hard disk.
+    ``pxe`` : boot to network.
+    ``no_override`` : use the system default boot target.
 
 If a target is not specified, boot_target makes no changes, and simply retrieves and returns the system boot target.  If ``target`` is specified and valid, the boot_target command will return the updated boot target value, as provided by the remote device.
 
@@ -700,8 +694,8 @@ Parameters
 :board_id: Hexadecimal string representation of 4-byte integer value - range 00000000..FFFFFFFF.  Upper byte of ``board_id`` reserved for future use in OpenDCRE.  IPMI Bridge board has a special ``board_id`` of 40NNNNNN, where NNNNNN corresponds to the hex string id of each configured BMC.
 :device_id: The device to issue LED control command to on the specified board.  Hexadecimal string representation of 2-byte integer value - range 0000..FFFF.  Must be a valid, existing device, where the ``device_type`` known to OpenDCRE is ``led`` - else, a 500 error is returned.
 :led_state: (optional)
-    - ``on`` : Turn on the chassis identify LED.
-    - ``off`` : Turn off the chassis identify LED.
+    ``on`` : Turn on the chassis identify LED. 
+    ``off`` : Turn off the chassis identify LED.
 
 Request Example
 ---------------

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -46,7 +46,7 @@ Request Example
 Response Schema
 ---------------
 
-::
+.. code-block:: json
 
     {
         "$schema": "http://schemas.vapor.io/opendcre/v1.2/opendcre-1.2-boards-devices",
@@ -95,7 +95,7 @@ Response Schema
 Example Response
 ----------------
 
-::
+.. code-block:: json
 
     {
       "boards": [
@@ -156,12 +156,12 @@ Request Example
 ---------------
 ::
 
-    https://opendcre:5000/opendcre/1.2/version/00000001
+    http://opendcre:5000/opendcre/1.2/version/00000001
 
 Response Schema
 ---------------
 
-::
+.. code-block:: json
 
     {
       "$schema": "http://schemas.vapor.io/opendcre/v1.2/opendcre-1.2-version",
@@ -183,7 +183,7 @@ Response Schema
 Example Response
 ----------------
 
-::
+.. code-block:: json
 
     {
       "api_version": "1.2",
@@ -205,6 +205,7 @@ Description
 - Read a value from the given ``board_id`` and ``device_id`` for a specific ``device_type``.  The specified ``device_type`` must match the actual physical device type (as reported by the ``scan`` command), and is used to return a translated raw reading value (e.g. temperature in C for a thermistor) based on the existing algorithm for a given sensor type.  The raw value is also returned.
 
 Request Format
+--------------
 ::
 
     http://<ipaddress>:<port>/opendcre/<version>/read/<device_type>/<board_id>/<device_id>
@@ -212,7 +213,7 @@ Request Format
 Parameters
 ----------
 
-- ``device_type``:  String value (lower-case) indicating what type of device to read:
+- ``device_type`` :  String value (lower-case) indicating what type of device to read
     - ``thermistor``
     - ``temperature``
     - ``humidity``
@@ -233,7 +234,7 @@ Request Example
 Response Schema
 ---------------
 
-::
+.. code-block:: json
 
     {
       "$schema": "http://schemas.vapor.io/opendcre/v1.2/opendcre-1.2-thermistor-reading",
@@ -249,7 +250,7 @@ Response Schema
 Example Response
 ----------------
 
-::
+.. code-block:: json
 
     {
       "temperature_c": 19.73
@@ -290,7 +291,7 @@ Request Example
 Response Schema
 ---------------
 
-::
+.. code-block:: json
 
     {
       "$schema": "http://schemas.vapor.io/opendcre/v1.2/opendcre-1.2-asset-information",
@@ -360,7 +361,7 @@ Response Schema
 Example Response
 ----------------
 
-::
+.. code-block:: json
 
     {
       "bmc_ip": "192.168.1.118",
@@ -428,7 +429,7 @@ Request Example
 Response Schema
 ---------------
 
-::
+.. code-block:: json
 
     {
       "$schema": "http://schemas.vapor.io/opendcre/v1.2/opendcre-1.2-power-status",
@@ -465,7 +466,7 @@ Response Schema
 Example Response
 ----------------
 
-::
+.. code-block:: json
 
     {
       "input_power": 0.0, 
@@ -521,7 +522,7 @@ Request Example
 Response Schema
 ---------------
 
-::
+.. code-block:: json
 
     {
       "$schema": "http://schemas.vapor.io/opendcre/v1.2/opendcre-1.2-boot-target",
@@ -537,7 +538,7 @@ Response Schema
 Example Response
 ----------------
 
-::
+.. code-block:: json
 
     {
       "target": "no_override"
@@ -573,7 +574,7 @@ Response Schema
 ---------------
 -Device Location:
 
-::
+.. code-block:: json
 
     {
       "$schema": "http://schemas.vapor.io/opendcre/v1.2/opendcre-1.2-device-location",
@@ -616,7 +617,7 @@ Response Schema
 
 - Board Location:
 
-::
+.. code-block:: json
 
     {
       "$schema": "http://schemas.vapor.io/opendcre/v1.2/opendcre-1.2-board-location",
@@ -644,7 +645,7 @@ Example Responses
 -----------------
 - Device Location:
 
-::
+.. code-block:: json
 
     {
       "chassis_location": {
@@ -670,7 +671,7 @@ Example Responses
 
 - Board Location:
 
-::
+.. code-block:: json
 
     {
       "physical_location": {
@@ -727,7 +728,7 @@ Request Example
 Response Schema
 ---------------
 
-::
+.. code-block:: json
 
     {
       "$schema": "http://schemas.vapor.io/opendcre/v1.2/opendcre-1.2-led-control",
@@ -743,7 +744,7 @@ Response Schema
 Example Response
 ----------------
 
-::
+.. code-block:: json
 
     {
       "led_state": "on"
@@ -789,7 +790,7 @@ Request Example
 Response Schema
 ---------------
 
-::
+.. code-block:: json
 
     {
       "$schema": "http://schemas.vapor.io/opendcre/v1.2/opendcre-1.2-fan-speed",
@@ -805,7 +806,7 @@ Response Schema
 Example Response
 ----------------
 
-::
+.. code-block:: json
 
     {
       "speed_rpm": 4100
@@ -833,7 +834,7 @@ Request Format
 Response Schema
 ---------------
 
-::
+.. code-block:: json
 
     {
       "$schema": "http://schemas.vapor.io/opendcre/v1.2/opendcre-1.2-test-status",
@@ -849,7 +850,7 @@ Response Schema
 Example Response
 ----------------
 
-::
+.. code-block:: json
 
     {
       "status": "ok" 

--- a/docs/source/emulator.rst
+++ b/docs/source/emulator.rst
@@ -5,7 +5,7 @@ OpenDCRE Emulator
 Emulator Configuration
 ----------------------
 
-In the absence of HAT hardware, OpenDCRE can utilize a software emulator, to simulate and test various capabilities of OpenDCRE.  The OpenDCRE emulator is configured by means of a JSON file (the default file is ``simple.json``) which is stored in the ``/opendcre/opendcre_southbound`` directory of the OpenDCRE Docker container.
+In the absence of HAT hardware, OpenDCRE can utilize a software emulator to simulate and test various capabilities of OpenDCRE.  The OpenDCRE emulator is configured by means of a JSON file (the default file is ``simple.json``) which is stored in the ``/opendcre/opendcre_southbound`` directory of the OpenDCRE Docker container.
 
 To modify the emulator output, users may clone the `OpenDCRE GitHub repository`__, and change the contents of ``simple.json``, then rebuild the OpenDCRE container.
 
@@ -14,7 +14,7 @@ To modify the emulator output, users may clone the `OpenDCRE GitHub repository`_
 __ OpenDCRE_
 
 Example emulator configuration from ``simple.json`` is below, followed by an explanation of the contents.
-::
+.. code-block:: json
 
     {
       "boards": [
@@ -646,7 +646,8 @@ The ``device_type`` field must be present, and must contain a string value that 
 - ``fan_speed``
 - ``temperature``
 
-In previous releases, a device type of ``none`` indicated that no device is present at a given ``device_id`` on the given board, and may be ignored.  In OpenDCRE v1.2 the ``none`` device type has been removed.
+.. versionchanged:: 1.2
+    In previous releases, a device type of ``none`` indicated that no device is present at a given ``device_id`` on the given board, and may be ignored.  In OpenDCRE v1.2 the ``none`` device type has been removed.
 
 Other device types (e.g. for additional sensors and actions) will be added in future revisions of OpenDCRE, or may be added by developers wishing to add support for other device types.
 
@@ -668,7 +669,7 @@ Device Type     Action Supported
 Read
 ----
 
-For the ``read`` action's field in the OpenDCRE emulator configuration, two fields may be configured, relating to the responses returned from a read command for the given device.
+For the ``read`` action's field in the OpenDCRE emulator configuration, two fields may be configured relating to the responses returned from a read command for the given device.
 
 First, the ``repeatable`` field may be set to true or false, depending on whether it is desirable for the list of responses set in the responses field to repeat in a round-robin fashion, or if a device should stop returning data after its response list has been exhausted.
 
@@ -679,7 +680,7 @@ When a list of values is provided for responses, the emulator iterates sequentia
 An empty responses list means the device returns no data, which translates to a 500 error for the read command at the OpenDCRE REST API level (useful for simulating errors).  To always return the same single value, a responses list with a single element, and repeatable set to "true" will suffice.
 
 Read Response Format
---------------------
+~~~~~~~~~~~~~~~~~~~~
 
 The table below describes the response format for each device type for ``read`` commands to the emulator.
 
@@ -689,7 +690,7 @@ Device Type     Format
 ``thermistor``  integer, converted by OpenDCRE (see ``simple.json``)
 ``temperature`` numeric, sent back as numeric value (e.g. 28.78)
 ``humidity``    numeric, converted by OpenDCRE
-``led``         integer - ``1`` is ``on`` and ``0`` is ``off``; all other values are errors
+``led``         integer, ``1`` is ``on`` and ``0`` is ``off``; all other values are errors
 ``fan_speed``   integer, sent back as integer value (e.g. 4100)
 =============== ==============================================
 
@@ -701,7 +702,7 @@ Write
 For the ``write`` action's field in the OpenDCRE emulator configuration, two fields may be configured, relating to the responses returned from a write command for the given device.  The fields are laid out and function in the same manner as ``read`` fields.
 
 Write Response Format
----------------------
+~~~~~~~~~~~~~~~~~~~~~
 
 The table below describes the response format for each device type for ``write`` commands to the emulator.
 

--- a/docs/source/emulator.rst
+++ b/docs/source/emulator.rst
@@ -14,6 +14,7 @@ To modify the emulator output, users may clone the `OpenDCRE GitHub repository`_
 __ OpenDCRE_
 
 Example emulator configuration from ``simple.json`` is below, followed by an explanation of the contents.
+
 .. code-block:: json
 
     {

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -42,24 +42,30 @@ Install
 -------
 
 Insert Micro SD card into card reader, and determine the SD card device:
+
 *MacOS*
-::
+
+.. code-block:: shell
 
     sudo diskutil list
 
 *Linux*
-::
+
+.. code-block:: shell
 
     sudo fdisk -l
 
 Use ``dd`` to write image to card:
+
 *Macos*
-::
+
+.. code-block:: shell
 
     sudo dd if=<.img file> of=<sd card device> bs=4m
 
 *Linux*
-::
+
+.. code-block:: shell
 
     sudo dd if=<.img file> of=<sd card device> bs=4M
 
@@ -68,19 +74,22 @@ Note:
     - ``<sd card device>`` is the SD card device determined in the previous step. (e.g. - /dev/disk1)
 
 When executing the above commands, if an error is returned similar to
-::
+
+.. code-block:: shell
 
     dd: <sd card device>: Resource busy
 
 then the SD card must be unmounted. To do this, identify the SD card partition (can use ``df -h`` for this, or the results from determining the SD card device, above), then unmount the partition:
 
 *MacOS*
-::
+
+.. code-block:: shell
 
     sudo diskutil unmount <sd card device>
 
 *Linux*
-::
+
+.. code-block:: shell
 
     sudo umount <sd card device>
 
@@ -113,7 +122,8 @@ Starting OpenDCRE
 OpenDCRE may be started manually for verification.
 
 To start OpenDCRE with the HAT device attached:
-::
+
+.. code-block:: shell
 
     docker run -d -p 5000:5000 -v /var/log/opendcre:/logs --privileged --device /dev/mem:/dev/mem --device /dev/ttyAMA0:/dev/ttyAMA0 opendcre ./start_opendcre.sh /dev/ttyAMA0 0
 
@@ -122,7 +132,8 @@ With Emulator
 -------------
 
 To start OpenDCRE in local emulator mode:
-::
+
+.. code-block:: shell
 
     docker run -d -p 5000:5000 -v /var/log/opendcre:/logs opendcre ./start_opendcre_emulator.sh
 
@@ -130,7 +141,8 @@ Run Tests
 ---------
 
 To run the OpenDCRE test suite (from the OpenDCRE root):
-::
+
+.. code-block:: shell
 
     make rpi-test
 
@@ -147,6 +159,7 @@ Navigate to:
     http://<openmistos ip address>:5000/opendcre/1.2/test
 
 Output should be similar to:
+
 .. code-block:: json
 
     {
@@ -156,10 +169,7 @@ Output should be similar to:
 Command-Line
 ~~~~~~~~~~~~
 
-Running:
-``$ docker ps``
-
-produces output similar to:
+Running: ``docker ps`` produces output similar to:
 ::
 
     CONTAINER ID        IMAGE                      COMMAND                CREATED          STATUS              PORTS                    NAMES

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -55,7 +55,7 @@ Install
         - ``<.img file>`` is the path and filename of the decompressed OpenMistOS .img downloaded above.
         - ``<sd card device>`` is the SD card device determined in the previous step. (e.g. - /dev/disk1)
 
-When executing the above commands, if an error is returned similar to: ``dd: <sd card device>: Resource busy`` then the SD card must be unmounted.To do this, identify the SD card partition (can use ``df -h`` for this, or the results from determining the SD card device, above), then unmount the partition:
+When executing the above commands, if an error is returned similar to: ``dd: <sd card device>: Resource busy`` then the SD card must be unmounted. To do this, identify the SD card partition (can use ``df -h`` for this, or the results from determining the SD card device, above), then unmount the partition:
 
 - *MacOS*:
     - ``sudo diskutil unmount <sd card device>``
@@ -90,7 +90,7 @@ OpenDCRE may be started manually for verification.
 To start OpenDCRE with the HAT device attached:
 ::
 
-    docker run -d -p 5000:5000 -v /var/log/opendcre:/logs --privileged --device /dev/mem:/dev/mem --device /dev/ttyAMA0:/dev/ttyAMA0 opendcre ./start_opendcre.sh /dev/ttyAMA0 0``
+    docker run -d -p 5000:5000 -v /var/log/opendcre:/logs --privileged --device /dev/mem:/dev/mem --device /dev/ttyAMA0:/dev/ttyAMA0 opendcre ./start_opendcre.sh /dev/ttyAMA0 0
 
 
 With Emulator
@@ -114,7 +114,7 @@ Verification
 There are several methods for verifying that OpenDCRE is running properly.
 
 Browser
--------
+~~~~~~~
 
 Navigate to:
 ::
@@ -129,7 +129,7 @@ Output should be similar to:
     }
 
 Command-Line
-------------
+~~~~~~~~~~~~
 
 Running:
 ``$ docker ps``

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -44,24 +44,24 @@ Install
 Insert Micro SD card into card reader, and determine the SD card device:
 
 MacOS
-    .. code-block:: shell
+    ::
 
         sudo diskutil list
 
 Linux
-    .. code-block:: shell
+    ::
 
         sudo fdisk -l
 
 Use ``dd`` to write image to card:
 
 Macos
-    .. code-block:: shell
+    ::
 
         sudo dd if=<.img file> of=<sd card device> bs=4m
 
 Linux
-    .. code-block:: shell
+    ::
 
         sudo dd if=<.img file> of=<sd card device> bs=4M
 
@@ -70,20 +70,19 @@ Note:
     - ``<sd card device>`` is the SD card device determined in the previous step. (e.g. - /dev/disk1)
 
 When executing the above commands, if an error is returned similar to
-
-.. code-block:: shell
+::
 
     dd: <sd card device>: Resource busy
 
 then the SD card must be unmounted. To do this, identify the SD card partition (can use ``df -h`` for this, or the results from determining the SD card device, above), then unmount the partition:
 
 MacOS
-    .. code-block:: shell
+    ::
 
         sudo diskutil unmount <sd card device>
 
 Linux
-    .. code-block:: shell
+    ::
 
         sudo umount <sd card device>
 
@@ -116,8 +115,7 @@ Starting OpenDCRE
 OpenDCRE may be started manually for verification.
 
 To start OpenDCRE with the HAT device attached:
-
-.. code-block:: shell
+::
 
     docker run -d -p 5000:5000 -v /var/log/opendcre:/logs --privileged --device /dev/mem:/dev/mem --device /dev/ttyAMA0:/dev/ttyAMA0 opendcre ./start_opendcre.sh /dev/ttyAMA0 0
 
@@ -126,8 +124,7 @@ With Emulator
 -------------
 
 To start OpenDCRE in local emulator mode:
-
-.. code-block:: shell
+::
 
     docker run -d -p 5000:5000 -v /var/log/opendcre:/logs opendcre ./start_opendcre_emulator.sh
 
@@ -135,8 +132,7 @@ Run Tests
 ---------
 
 To run the OpenDCRE test suite (from the OpenDCRE root):
-
-.. code-block:: shell
+::
 
     make rpi-test
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -41,26 +41,48 @@ __ OpenDCRE_
 Install
 -------
 
-- Insert Micro SD card into card reader, and determine the SD card device:
-    - MacOS: 
-        - ``sudo diskutil list``
-    - Linux:  
-        - ``sudo fdisk -l``
-- Use ``dd`` to write image to card:
-    - MacOS: 
-        - ``sudo dd if=<.img file> of=<sd card device> bs=4m``
-    - Linux: 
-        - ``sudo dd if=<.img file> of=<sd card device> bs=4M``
-    - Note:
-        - ``<.img file>`` is the path and filename of the decompressed OpenMistOS .img downloaded above.
-        - ``<sd card device>`` is the SD card device determined in the previous step. (e.g. - /dev/disk1)
+Insert Micro SD card into card reader, and determine the SD card device:
+*MacOS*
+::
 
-When executing the above commands, if an error is returned similar to: ``dd: <sd card device>: Resource busy`` then the SD card must be unmounted. To do this, identify the SD card partition (can use ``df -h`` for this, or the results from determining the SD card device, above), then unmount the partition:
+    sudo diskutil list
 
-- *MacOS*:
-    - ``sudo diskutil unmount <sd card device>``
-- *Linux*: 
-    - ``sudo umount <sd card device>``
+*Linux*
+::
+
+    sudo fdisk -l
+
+Use ``dd`` to write image to card:
+*Macos*
+::
+
+    sudo dd if=<.img file> of=<sd card device> bs=4m
+
+*Linux*
+::
+
+    sudo dd if=<.img file> of=<sd card device> bs=4M
+
+Note:
+    - ``<.img file>`` is the path and filename of the decompressed OpenMistOS .img downloaded above.
+    - ``<sd card device>`` is the SD card device determined in the previous step. (e.g. - /dev/disk1)
+
+When executing the above commands, if an error is returned similar to
+::
+
+    dd: <sd card device>: Resource busy
+
+then the SD card must be unmounted. To do this, identify the SD card partition (can use ``df -h`` for this, or the results from determining the SD card device, above), then unmount the partition:
+
+*MacOS*
+::
+
+    sudo diskutil unmount <sd card device>
+
+*Linux*
+::
+
+    sudo umount <sd card device>
 
 When ``dd`` is complete, OpenMistOS is ready to run from the SD card.  Plug the Raspberry Pi into the wired network, insert the Micro SD card, and power up the Raspberry Pi.
 
@@ -77,11 +99,14 @@ SSH into the OpenMistOS device:
 
 The ``openmistos`` user has ``sudo`` and Docker rights on OpenMistOS.  It is recommended to **immediately** change the ``openmistos`` password to a new, secure, password.
 
-**Note**: OpenMistOS, like other Raspberry Pi OSes, uses only the space required for the OS on the SD card. It is recommended to change this behavior so that the entire space on the SD card is used. To do this, enter the configuration menu on first login:
+.. note::
 
-``$ sudo raspi-config``
+    OpenMistOS, like other Raspberry Pi OSes, uses only the space required for the OS on the SD card. It is recommended to change this behavior so that the entire space on the SD card is used. To do this, enter the configuration menu on first login:
+    ::
 
-In the configuration menu, there should be an option to use the entire disk. Once selected and confirmed, OpenMistOS will restart and the entire SD card will then be used.
+        $ sudo raspi-config
+
+    In the configuration menu, there should be an option to use the entire disk. Once selected and confirmed, OpenMistOS will restart and the entire SD card will then be used.
 
 Starting OpenDCRE
 -----------------
@@ -122,7 +147,7 @@ Navigate to:
     http://<openmistos ip address>:5000/opendcre/1.2/test
 
 Output should be similar to:
-::
+.. code-block:: json
 
     {
         "status": "ok"

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -43,31 +43,27 @@ Install
 
 Insert Micro SD card into card reader, and determine the SD card device:
 
-*MacOS*
+MacOS
+    .. code-block:: shell
 
-.. code-block:: shell
+        sudo diskutil list
 
-    sudo diskutil list
+Linux
+    .. code-block:: shell
 
-*Linux*
-
-.. code-block:: shell
-
-    sudo fdisk -l
+        sudo fdisk -l
 
 Use ``dd`` to write image to card:
 
-*Macos*
+Macos
+    .. code-block:: shell
 
-.. code-block:: shell
+        sudo dd if=<.img file> of=<sd card device> bs=4m
 
-    sudo dd if=<.img file> of=<sd card device> bs=4m
+Linux
+    .. code-block:: shell
 
-*Linux*
-
-.. code-block:: shell
-
-    sudo dd if=<.img file> of=<sd card device> bs=4M
+        sudo dd if=<.img file> of=<sd card device> bs=4M
 
 Note:
     - ``<.img file>`` is the path and filename of the decompressed OpenMistOS .img downloaded above.
@@ -81,17 +77,15 @@ When executing the above commands, if an error is returned similar to
 
 then the SD card must be unmounted. To do this, identify the SD card partition (can use ``df -h`` for this, or the results from determining the SD card device, above), then unmount the partition:
 
-*MacOS*
+MacOS
+    .. code-block:: shell
 
-.. code-block:: shell
+        sudo diskutil unmount <sd card device>
 
-    sudo diskutil unmount <sd card device>
+Linux
+    .. code-block:: shell
 
-*Linux*
-
-.. code-block:: shell
-
-    sudo umount <sd card device>
+        sudo umount <sd card device>
 
 When ``dd`` is complete, OpenMistOS is ready to run from the SD card.  Plug the Raspberry Pi into the wired network, insert the Micro SD card, and power up the Raspberry Pi.
 
@@ -165,6 +159,7 @@ Output should be similar to:
     {
         "status": "ok"
     }
+
 
 Command-Line
 ~~~~~~~~~~~~

--- a/docs/source/ipmi.rst
+++ b/docs/source/ipmi.rst
@@ -26,7 +26,7 @@ Configuration
 The Vapor IPMI bridge is configured via the ``bmc_config.json`` file, which must be placed in the top level of the OpenDCRE distribution.  An example file, ``bmc_config_sample.json`` is included with OpenDCRE (located in the ``opendcre_southbound`` directory), and may be modified to one's environment.
 
 All IPMI BMCs successfully configured will show up on a ``scan`` command result as devices under ``board_id`` 40000000.
-::
+.. code-block:: json
 
     {
       "bmcs": [
@@ -68,7 +68,7 @@ If a field is missing, or the ``bmc_config.json`` file is improperly formatted, 
 
 Once the configuration file has been successfully edited, rebuild the OpenDCRE Docker container, and verify the configured BMC devices are returned via a ``scan`` command.
 
-Each BMC device will show up as a board, with ``board_id`` in the range of ``40000001``..``40FFFFFF``.
+Each BMC device will show up as a board, with ``board_id`` in the range of ``40000001`` ... ``40FFFFFF``.
 
 OpenDCRE commands may be issued against IPMI and PLC devices without change in command format.
 

--- a/docs/source/ipmi.rst
+++ b/docs/source/ipmi.rst
@@ -26,6 +26,7 @@ Configuration
 The Vapor IPMI bridge is configured via the ``bmc_config.json`` file, which must be placed in the top level of the OpenDCRE distribution.  An example file, ``bmc_config_sample.json`` is included with OpenDCRE (located in the ``opendcre_southbound`` directory), and may be modified to one's environment.
 
 All IPMI BMCs successfully configured will show up on a ``scan`` command result as devices under ``board_id`` 40000000.
+
 .. code-block:: json
 
     {

--- a/docs/source/run.rst
+++ b/docs/source/run.rst
@@ -16,7 +16,7 @@ With HAT
 To start OpenDCRE with the HAT device attached:
 ::
 
-    docker run -d -p 5000:5000 -v /var/log/opendcre:/logs --privileged --device /dev/mem:/dev/mem --device /dev/ttyAMA0:/dev/ttyAMA0 opendcre ./start_opendcre.sh``
+    docker run -d -p 5000:5000 -v /var/log/opendcre:/logs --privileged --device /dev/mem:/dev/mem --device /dev/ttyAMA0:/dev/ttyAMA0 opendcre ./start_opendcre.sh
 
 With Emulator
 -------------

--- a/docs/source/update.rst
+++ b/docs/source/update.rst
@@ -8,12 +8,14 @@ OpenDCRE Updates
 In OpenMistOS, upgrades to OpenDCRE may be carried out by updating the OpenDCRE docker container.  To do this, first stop OpenDCRE.
 
 Then, log in to Docker Hub (assumes OpenMistOS has Internet access):
+::
 
-``$ docker login``
+    $ docker login
 
 (enter your Docker Hub username, password and email address)
+::
 
-``$ docker pull vaporio/opendcre``
+    $ docker pull vaporio/opendcre
 
 If an update is available, the latest version of opendcre will be pulled down to OpenMistOS.
 
@@ -23,5 +25,7 @@ OpenMistOS Updates
 ------------------
 
 To update OpenMistOS:
+::
 
-``$ sudo apt-get update && sudo apt-get upgrade``
+    $ sudo apt-get update && sudo apt-get upgrade
+


### PR DESCRIPTION
this includes fixes for
 - typos/grammar corrections
 - formatting of notes blocks
 - code block formatting (apply JSON syntax highlighting, where appropriate)
 - clean up pages with excessive and unnecessary use of bulleted lists