### PR TITLE
#24 - ensure Flask is 0.10.1 due to custom error handling issues intr…

### DIFF
--- a/Dockerfile.macos
+++ b/Dockerfile.macos
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y \
     --no-install-recommends && \
     rm -rf /var/lib/apt/lists/*
 RUN pip install pyserial==2.7
-RUN pip install flask
+RUN pip install flask==0.10.1
 RUN pip install requests
 RUN pip install lockfile
 RUN pip install uwsgi

--- a/Dockerfile.rpi
+++ b/Dockerfile.rpi
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y \
     --no-install-recommends && \
     rm -rf /var/lib/apt/lists/*
 RUN pip install pyserial==2.7
-RUN pip install flask
+RUN pip install flask==0.10.1
 RUN pip install requests
 RUN pip install uwsgi
 RUN pip install RPi.GPIO


### PR DESCRIPTION
…oduced in Flask 11 - temporary fix until Flask is patched

Signed-off-by: Andrew Cencini <andrew@vapor.io>